### PR TITLE
fix(abex-relic-sell): Take unlocked relics in account

### DIFF
--- a/components/pages/AbexRelicSell/hooks/useCurrentToGoal.test.ts
+++ b/components/pages/AbexRelicSell/hooks/useCurrentToGoal.test.ts
@@ -3,7 +3,7 @@ import HeroClass from "../../../../types/HeroClass";
 import useCurrentToGoal from "./useCurrentToGoal";
 
 describe("Test useCurrentToGoal", () => {
-  it("For basic resources, should return the cost itself", () => {
+  it("For basic relics, should return the relic itself", () => {
     const { result } = renderHook(() =>
       useCurrentToGoal(
         {
@@ -26,7 +26,7 @@ describe("Test useCurrentToGoal", () => {
     expect(result.current).toEqual([1106]);
   });
 
-  it("For advanced resources, should return the cost itself", () => {
+  it("For max relics, should return all the dependencies", () => {
     const { result } = renderHook(() =>
       useCurrentToGoal(
         {
@@ -47,5 +47,28 @@ describe("Test useCurrentToGoal", () => {
     );
 
     expect(result.current).toEqual([1106, 2106, 3106, 4106, 5106]);
+  });
+
+  it("For max relics with already unlock levels, should return partial dependencies", () => {
+    const { result } = renderHook(() =>
+      useCurrentToGoal(
+        {
+          [HeroClass.ranger]: [0, 0, 0, 0, 0, 0],
+          [HeroClass.mage]: [0, 0, 0, 0, 0, 0],
+          [HeroClass.tank]: [0, 0, 0, 0, 0, 0],
+          [HeroClass.warrior]: [0, 0, 0, 0, 0, 4106],
+          [HeroClass.support]: [0, 0, 0, 0, 0, 0],
+        },
+        {
+          [HeroClass.ranger]: [0, 0, 0, 0, 0, 0],
+          [HeroClass.mage]: [0, 0, 0, 0, 0, 0],
+          [HeroClass.tank]: [0, 0, 0, 0, 0, 0],
+          [HeroClass.warrior]: [0, 0, 0, 0, 0, 5106],
+          [HeroClass.support]: [0, 0, 0, 0, 0, 0],
+        }
+      )
+    );
+
+    expect(result.current).toEqual([5106]);
   });
 });

--- a/components/pages/AbexRelicSell/hooks/useCurrentToGoal.ts
+++ b/components/pages/AbexRelicSell/hooks/useCurrentToGoal.ts
@@ -23,6 +23,11 @@ export default function useCurrentToGoal(currents: Current, goals: Current) {
           neededRelics.push(theTree[position]);
           newLevel = `${parseInt(newLevel, 10) - 1}` as Level;
           theTree = theClassTree[newLevel];
+
+          // The relic is the current one, we don't need to go further
+          if (theTree[position] === currents[theHeroClass][position]) {
+            break;
+          }
         }
       }
     });


### PR DESCRIPTION
Previous this commit, the unlocked relics were not taking in account to calculate the amount of relics that are to sell.
 - Add a test to illustrate the bug
 - Break the relic tree lookaround when the current one is reached