### PR TITLE
fix(abex-relic-sell): Current could be higher than goal

### DIFF
--- a/components/pages/AbexRelicSell/hooks/useCurrentToGoal.test.ts
+++ b/components/pages/AbexRelicSell/hooks/useCurrentToGoal.test.ts
@@ -71,4 +71,27 @@ describe("Test useCurrentToGoal", () => {
 
     expect(result.current).toEqual([5106]);
   });
+
+  it("If current is higher than goal, should return empty array", () => {
+    const { result } = renderHook(() =>
+      useCurrentToGoal(
+        {
+          [HeroClass.ranger]: [0, 0, 0, 0, 0, 0],
+          [HeroClass.mage]: [0, 0, 0, 0, 0, 0],
+          [HeroClass.tank]: [0, 0, 0, 0, 0, 0],
+          [HeroClass.warrior]: [0, 0, 0, 0, 0, 5106],
+          [HeroClass.support]: [0, 0, 0, 0, 0, 0],
+        },
+        {
+          [HeroClass.ranger]: [0, 0, 0, 0, 0, 0],
+          [HeroClass.mage]: [0, 0, 0, 0, 0, 0],
+          [HeroClass.tank]: [0, 0, 0, 0, 0, 0],
+          [HeroClass.warrior]: [0, 0, 0, 0, 0, 1106],
+          [HeroClass.support]: [0, 0, 0, 0, 0, 0],
+        }
+      )
+    );
+
+    expect(result.current).toEqual([]);
+  });
 });

--- a/components/pages/AbexRelicSell/hooks/useCurrentToGoal.ts
+++ b/components/pages/AbexRelicSell/hooks/useCurrentToGoal.ts
@@ -12,8 +12,11 @@ export default function useCurrentToGoal(currents: Current, goals: Current) {
     const theClassTree = abexRelicData.tree[theHeroClass];
 
     goals[theHeroClass].forEach((relic, index) => {
-      if (currents[theHeroClass][index] !== relic) {
-        const level = `${Math.floor(relic / 1000)}` as Level;
+      const goalRelicLevel = Math.floor(relic / 1000);
+      const currentRelicLevel = Math.floor(currents[theHeroClass][index] / 1000);
+
+      if (goalRelicLevel > currentRelicLevel) {
+        const level = `${goalRelicLevel}` as Level;
         const position = theClassTree[level].indexOf(relic);
 
         let newLevel = level;


### PR DESCRIPTION
When the current relics are higher than the goal relics, the application should not consider any workload since the goal should be marked as done