### PR TITLE
Numeric input fields to make inputs a bit more accessible.

### DIFF
--- a/components/modal/ChooseHero.tsx
+++ b/components/modal/ChooseHero.tsx
@@ -54,6 +54,7 @@ const ChooseHero: React.FC<Props> = function ChooseHero({
             style={{ width: "60px" }}
             small
             name="si"
+            type="number"
             label={t(`concept.si`)}
             value={si}
             onChange={(value) => onSelect(DetailType.SI, parseInt(value, 10))}
@@ -62,6 +63,7 @@ const ChooseHero: React.FC<Props> = function ChooseHero({
             style={{ width: "60px" }}
             small
             name="fi"
+            type="number"
             label={t(`concept.fi`)}
             value={fi}
             onChange={(value) => onSelect(DetailType.INN, parseInt(value, 10))}

--- a/components/modal/ChoosePetStep.tsx
+++ b/components/modal/ChoosePetStep.tsx
@@ -56,6 +56,7 @@ const ChoosePetStep: React.FC<Props> = function ChoosePetStep({ pet = 6001, leve
           style={{ width: "100px" }}
           small
           name="si"
+          type="number"
           label={t(`level`)}
           value={level}
           onChange={(value) =>

--- a/components/modal/ChooseTreeStep.tsx
+++ b/components/modal/ChooseTreeStep.tsx
@@ -46,6 +46,7 @@ const ChooseTreeStep: React.FC<Props> = function ChooseTreeStep({
           style={{ width: "100px" }}
           small
           name="si"
+          type="number"
           label={t(`concept.si`)}
           value={level}
           onChange={(value) =>

--- a/components/modal/components/ui/AgilityBuffForm.tsx
+++ b/components/modal/components/ui/AgilityBuffForm.tsx
@@ -26,6 +26,7 @@ const AgilityBuffForm: React.FC<Props> = function AgilityBuffForm({ agilityBuff,
       <InputField
         small
         name="agilityBuff"
+        type="number"
         label={t(`concept.agilityBuff`)}
         value={agilityBuff}
         onChange={(agilityBuffValue) => onChange(parseInt(agilityBuffValue, 10))}

--- a/components/modal/components/ui/AscendForm.tsx
+++ b/components/modal/components/ui/AscendForm.tsx
@@ -24,6 +24,7 @@ const AscendForm: React.FC<Props> = function AscendForm({ isAwakened, ascend, on
       }))}
       small
       name="ascend"
+      type="number"
       label={t(`concept.ascend`)}
       value={ascend}
       onChange={(value) => onChange(parseInt(value, 10))}

--- a/components/modal/components/ui/EngraveForm.tsx
+++ b/components/modal/components/ui/EngraveForm.tsx
@@ -40,6 +40,7 @@ const EngraveForm: React.FC<Props> = function EngraveForm({ hero, engrave, onCha
       <InputField
         small
         name="engrave"
+        type="number"
         label={t(`concept.engrave`)}
         value={engrave}
         onChange={(engraveValue) => onChange(parseInt(engraveValue, 10))}

--- a/components/modal/components/ui/FiForm.tsx
+++ b/components/modal/components/ui/FiForm.tsx
@@ -23,6 +23,7 @@ const FiForm: React.FC<Props> = function FiForm({ fi, onChange }) {
       <InputField
         small
         name="fi"
+        type="number"
         label={t(`concept.fi`)}
         value={fi}
         onChange={(fiValue) => onChange(parseInt(fiValue, 10))}

--- a/components/modal/components/ui/IntelligenceBuffForm.tsx
+++ b/components/modal/components/ui/IntelligenceBuffForm.tsx
@@ -29,6 +29,7 @@ const IntelligenceBuffForm: React.FC<Props> = function IntelligenceBuffForm({
       <InputField
         small
         name="intelligenceBuff"
+        type="number"
         label={t(`concept.intelligenceBuff`)}
         value={intelligenceBuff}
         onChange={(intelligenceBuffValue) => onChange(parseInt(intelligenceBuffValue, 10))}

--- a/components/modal/components/ui/SiForm.tsx
+++ b/components/modal/components/ui/SiForm.tsx
@@ -57,6 +57,7 @@ const SiForm: React.FC<Props> = function SiForm({ hero, si, onChange }) {
         <InputField
           small
           name="si"
+          type="number"
           label={t(`concept.si`)}
           value={si === -1 ? "" : si}
           disabled={si === -1}

--- a/components/modal/components/ui/StrengthBuffForm.tsx
+++ b/components/modal/components/ui/StrengthBuffForm.tsx
@@ -26,6 +26,7 @@ const StrengthBuffForm: React.FC<Props> = function StrengthBuffForm({ strengthBu
       <InputField
         small
         name="strengthBuff"
+        type="number"
         label={t(`concept.strengthBuff`)}
         value={strengthBuff}
         onChange={(strengthBuffValue) => onChange(parseInt(strengthBuffValue, 10))}

--- a/components/pages/HeroList/ui/FiField.tsx
+++ b/components/pages/HeroList/ui/FiField.tsx
@@ -31,6 +31,7 @@ const FiField: React.FC<IProps> = function FiField({
       maxLength={1}
       style={{ width: "32px", textAlign: "center" }}
       name={`fi-${id}`}
+      type="number"
       inputMode="numeric"
     />
   );

--- a/components/pages/HeroList/ui/Filters.tsx
+++ b/components/pages/HeroList/ui/Filters.tsx
@@ -102,6 +102,7 @@ const Filters: React.FC<IProps> = function Filters({ force, state, dispatch }) {
             label={t("common:concept.si")}
             dispatch={dispatch}
             name="si"
+            type="number"
           />
           <InputFilter
             value={state.fi}
@@ -109,6 +110,7 @@ const Filters: React.FC<IProps> = function Filters({ force, state, dispatch }) {
             label={t("common:concept.fi")}
             dispatch={dispatch}
             name="fi"
+            type="number"
           />
           <SelectFilter
             value={state.ascend}
@@ -127,6 +129,7 @@ const Filters: React.FC<IProps> = function Filters({ force, state, dispatch }) {
             label={t("common:concept.engrave")}
             dispatch={dispatch}
             name="engrave"
+            type="number"
           />
           <SelectFilter
             value={state.equip}

--- a/components/pages/HeroList/ui/InputFilter.tsx
+++ b/components/pages/HeroList/ui/InputFilter.tsx
@@ -20,6 +20,7 @@ const InputFilter: React.FC<IProps> = function InputFilter({
   dispatch,
   name,
   label,
+  type = "text"
 }) {
   return (
     <div className={styles.Wrapper}>
@@ -41,6 +42,7 @@ const InputFilter: React.FC<IProps> = function InputFilter({
       <input
         className={styles.Value}
         value={value}
+        type={type}
         onChange={(e) => dispatch({ type: name, value: e.target.value })}
       />
     </div>

--- a/components/pages/HeroList/ui/SiField.tsx
+++ b/components/pages/HeroList/ui/SiField.tsx
@@ -24,6 +24,7 @@ const SiField: React.FC<IProps> = function SiField({ id, setLevel, getValue, isV
       maxLength={2}
       style={{ width: "32px", textAlign: "center" }}
       name={`si-${id}`}
+      type="number"
       inputMode="numeric"
     />
   );

--- a/components/pages/ItemCost/ui/ResourceDetail.tsx
+++ b/components/pages/ItemCost/ui/ResourceDetail.tsx
@@ -38,6 +38,7 @@ const ResourceDetail: React.FC<Props> = function ResourceDetail({
         value={value}
         onChange={(v) => onValue(v || "0")}
         name={`resource-count-${side}-${resource}`}
+        type="number"
         style={{ width: "90px" }}
       />
       <div className={styles.Cost}>

--- a/components/pages/TiersList/ui/Owner.tsx
+++ b/components/pages/TiersList/ui/Owner.tsx
@@ -137,6 +137,7 @@ const Owner: React.FC<IProps> = function Owner({ listId, result }) {
           <InputField
             label={t("label-value")}
             name="requirementValue"
+            type="number"
             value={requirementValue}
             onChange={(newValue) => setRequirementValue(listId, parseFloat(newValue || "0"))}
           />

--- a/pages/elite-summon/index.tsx
+++ b/pages/elite-summon/index.tsx
@@ -55,36 +55,42 @@ const EliteSummon: React.FC<IProps> = function EliteSummon() {
         <InputField
           value={elite}
           name="current-elite"
+          type="number"
           label={t("current-elite")}
           onChange={onChange(setElite)}
         />
         <InputField
           value={eliteP}
           name="current-elite-p"
+          type="number"
           label={t("current-elite-p")}
           onChange={onChange(setEliteP)}
         />
         <InputField
           value={legendary}
           name="current-legendary"
+          type="number"
           label={t("current-legendary")}
           onChange={onChange(setLegendary)}
         />
         <InputField
           value={legendaryP}
           name="current-legendary-p"
+          type="number"
           label={t("current-legendary-p")}
           onChange={onChange(setLegendaryP)}
         />
         <InputField
           value={mythic}
           name="current-mythic"
+          type="number"
           label={t("current-mythic")}
           onChange={onChange(setMythic)}
         />
         <InputField
           value={mythicP}
           name="current-mythic-p"
+          type="number"
           label={t("current-mythic-p")}
           onChange={onChange(setMythicP)}
         />

--- a/pages/fast-reward/index.tsx
+++ b/pages/fast-reward/index.tsx
@@ -64,6 +64,7 @@ const FastReward: React.FC<IProps> = function FastReward() {
         />
         <InputField
           inputMode="numeric"
+          type="number"
           name="player-level"
           value={playerLevel}
           label={t("player-level")}

--- a/pages/signature-item/index.tsx
+++ b/pages/signature-item/index.tsx
@@ -61,12 +61,14 @@ const SignatureItem: React.FC<IProps> = function SignatureItem() {
 
         <InputField
           name="current-si"
+          type="number"
           value={currentLevel}
           label={t("label-current-si")}
           onChange={onChange(setCurrentLevel)}
         />
         <InputField
           name="target-si"
+          type="number"
           value={targetLevel}
           label={t("label-target-si")}
           onChange={onChange(setTargetLevel)}


### PR DESCRIPTION
This PR simply marks all inputs used for numbers with `type="number"`, as that makes the browser use its built-in number input (with up arrow increments, for example) that is a bit better to use in these cases.